### PR TITLE
change access scope of `DataBus#handlers` to protected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Change log
 
+## Version 2.0.1
+サードパーティ製のDataBusを開発できるようにするため, `DataBus#handlers` のアクセス修飾子を `protected` に変更。
+
 ## Version 2.0.0
 初版

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 ### gradle
 ```
 dependencies {
-	compile 'jp.co.dwango.cbb:data-bus:2.0.0'
+	compile 'jp.co.dwango.cbb:data-bus:2.0.1'
 }
 ```
 

--- a/data-bus/build.gradle
+++ b/data-bus/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'com.novoda.bintray-release'
-def pomVersion = "2.0.0"
+def pomVersion = "2.0.1"
 
 buildscript {
     repositories {

--- a/data-bus/src/main/java/jp/co/dwango/cbb/db/DataBus.java
+++ b/data-bus/src/main/java/jp/co/dwango/cbb/db/DataBus.java
@@ -7,7 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public abstract class DataBus {
-	final List<DataBusHandler> handlers = new ArrayList<DataBusHandler>();
+	protected final List<DataBusHandler> handlers = new ArrayList<DataBusHandler>();
 	protected boolean destroyed = false;
 
 	public static void logging(boolean enabled) {


### PR DESCRIPTION
`DataBus#handlers` のアクセス修飾子を無名にしていたが, このままではサードパーティが独自のDataBusを開発することができないため, `protected` に変更します。
- [x] cross check
- [x] publish