### PR TITLE
Android Studio 2.3対応 + マルチスレッド対応

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## Version 2.0.3
+- 依存する Gradle と Build Tools を Android Studio 2.3 対応バージョンに更新
+- `DataBus#handlers` をスレッドセーフな形に修正
+
 ## Version 2.0.2
 `MultiplexDataBus` で要素に `null` を含む `JSONArray` を送受信するとクラッシュする問題を修正。
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 ### gradle
 ```
 dependencies {
-	compile 'jp.co.dwango.cbb:data-bus:2.0.2'
+	compile 'jp.co.dwango.cbb:data-bus:2.0.3'
 }
 ```
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "24.0.2"
+    buildToolsVersion '25.0.0'
     defaultConfig {
         applicationId "jp.co.dwango.cbb.db.test"
         minSdkVersion 16

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.0'
     }
 }
 

--- a/data-bus/build.gradle
+++ b/data-bus/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'com.novoda.bintray-release'
-def pomVersion = "2.0.2"
+def pomVersion = "2.0.3"
 
 buildscript {
     repositories {

--- a/data-bus/build.gradle
+++ b/data-bus/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    buildToolsVersion '25.0.0'
 
     defaultConfig {
         minSdkVersion 16

--- a/data-bus/src/main/java/jp/co/dwango/cbb/db/DataBus.java
+++ b/data-bus/src/main/java/jp/co/dwango/cbb/db/DataBus.java
@@ -4,10 +4,11 @@ package jp.co.dwango.cbb.db;
 import org.json.JSONArray;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public abstract class DataBus {
-	protected final List<DataBusHandler> handlers = new ArrayList<DataBusHandler>();
+	protected final List<DataBusHandler> handlers = Collections.synchronizedList(new ArrayList<DataBusHandler>());
 	protected boolean destroyed = false;
 
 	public static void logging(boolean enabled) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 28 10:00:20 PST 2015
+#Wed Mar 22 18:22:43 JST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
1. gradleとbuild-toolsをAndroid Studio 2.3に対応したバージョンに更新
2. `DataBus#handlers` をマルチスレッドセーフな形に修正