### PR TITLE
V2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change log
 
+## Version 2.1.1
+- nativeのWebViewDataBusから送信したテキスト内容が不正に変換される問題を __Android 4.4(KitKat) 以降__ でのみ対策
+  - Android 4.3以前ではこの問題は解消されません
+- テストプログラムが実機で動作できる形に修正
+  - WebViewDataBusのJavaScriptのインジェクション方式を自動から手動に変更
+  - __自動インジェクションは実機では正常に動作しない (現状回避策が無い)__
+- 依存するgradleのバージョンを更新
+
 ## Version 2.1.0
 - `DataBus` をスレッドセーフ化（破壊的変更）
   - `DataBus#handlers` を `private` に変更

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 ### gradle
 ```
 dependencies {
-	compile 'jp.co.dwango.cbb:data-bus:2.1.0'
+	compile 'jp.co.dwango.cbb:data-bus:2.1.1'
 }
 ```
 

--- a/app/src/main/assets/html/index.html
+++ b/app/src/main/assets/html/index.html
@@ -1,6 +1,7 @@
 <html>
 <head>
     <meta name="viewport" content="width=480,user-scalable=no"/>
+    <script type="text/javascript">$(WEB-VIEW-DATA-BUS)</script>
     <script type="text/javascript" src="file:///android_asset/html/script.js"></script>
 </head>
 <body>

--- a/app/src/main/java/jp/co/dwango/cbb/db/test/MainActivity.java
+++ b/app/src/main/java/jp/co/dwango/cbb/db/test/MainActivity.java
@@ -53,7 +53,7 @@ public class MainActivity extends AppCompatActivity {
 		});
 
 		// WebViewDataBusを用いるWebViewを指定してインスタンス化
-		final DataBus dataBus = new WebViewDataBus(this, webView);
+		final WebViewDataBus dataBus = new WebViewDataBus(this, webView, true);
 
 		// WebView(JavaScript) から メッセージ を受け取る ハンドラ を登録
 		final DataBusHandler handler = new DataBusHandler() {
@@ -93,7 +93,8 @@ public class MainActivity extends AppCompatActivity {
 		});
 
 		// WebView へコンテンツをロード
-		webView.loadDataWithBaseURL("", loadTextFromAsset("html/index.html"), "text/html", "UTF-8", null);
+		String html = loadTextFromAsset("html/index.html");
+		webView.loadDataWithBaseURL("", html.replace("$(WEB-VIEW-DATA-BUS)", dataBus.getInjectJavaScript()), "text/html", "UTF-8", null);
 	}
 
 	// assetsからテキストファイルを読み込む

--- a/app/src/main/java/jp/co/dwango/cbb/db/test/MainActivity.java
+++ b/app/src/main/java/jp/co/dwango/cbb/db/test/MainActivity.java
@@ -81,7 +81,7 @@ public class MainActivity extends AppCompatActivity {
 		findViewById(R.id.native_button_send).setOnClickListener(new View.OnClickListener() {
 			@Override
 			public void onClick(View v) {
-				dataBus.send(new JSONArray().put("test").put(2525).put(true));
+				dataBus.send(new JSONArray().put("test%10%20%30test").put(2525).put(true));
 			}
 		});
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 

--- a/data-bus/build.gradle
+++ b/data-bus/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'com.novoda.bintray-release'
-def pomVersion = "2.1.0"
+def pomVersion = "2.1.1"
 
 buildscript {
     repositories {

--- a/data-bus/src/main/java/jp/co/dwango/cbb/db/WebViewDataBus.java
+++ b/data-bus/src/main/java/jp/co/dwango/cbb/db/WebViewDataBus.java
@@ -194,12 +194,21 @@ public class WebViewDataBus extends DataBus {
 		}
 		String encoded = Base64.encodeToString(script.getBytes(), Base64.NO_WRAP);
 		Logger.d("inject: " + encoded);
-		webView.loadUrl("javascript:(function() {" +
-				"var script = document.createElement('script');" +
-				"script.type = 'text/javascript';" +
-				"script.innerHTML = window.atob('" + encoded + "');" +
-				"document.getElementsByTagName('head').item(0).appendChild(script)" +
-				"})()");
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+			webView.evaluateJavascript("(function() {" +
+					"var script = document.createElement('script');" +
+					"script.type = 'text/javascript';" +
+					"script.innerHTML = window.atob('" + encoded + "');" +
+					"document.getElementsByTagName('head').item(0).appendChild(script)" +
+					"})()", null);
+		} else {
+			webView.loadUrl("javascript:(function() {" +
+					"var script = document.createElement('script');" +
+					"script.type = 'text/javascript';" +
+					"script.innerHTML = window.atob('" + encoded + "');" +
+					"document.getElementsByTagName('head').item(0).appendChild(script)" +
+					"})()");
+		}
 	}
 
 	/**
@@ -248,10 +257,17 @@ public class WebViewDataBus extends DataBus {
 		((Activity) context).runOnUiThread(new Runnable() {
 			@Override
 			public void run() {
-				webView.loadUrl(String.format(
-						"javascript: window.AndroidDataBusNI.onSend(%s);",
-						data.toString()
-				));
+				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+					webView.evaluateJavascript(String.format(
+							"window.AndroidDataBusNI.onSend(%s);",
+							data.toString()
+					), null);
+				} else {
+					webView.loadUrl(String.format(
+							"javascript: window.AndroidDataBusNI.onSend(%s);",
+							data.toString()
+					));
+				}
 			}
 		});
 	}


### PR DESCRIPTION
次の変更をします
- nativeのWebViewDataBusから送信したテキスト内容が不正に変換される問題を __Android 4.4(KitKat) 以降__ でのみ対策
  - Android 4.3以前ではこの問題は解消されません
- テストプログラムを実機で動作できる形に修正
  - WebViewDataBusのJavaScriptのインジェクション方式を自動から手動に変更
  - __自動インジェクションは実機では正常に動作しない (現状回避策が無い)__
- 依存するgradleのバージョンを更新